### PR TITLE
Add worktree isolation to dev-workflow and controller-refactor-plan skill

### DIFF
--- a/skills/controller-refactor-plan/SKILL.md
+++ b/skills/controller-refactor-plan/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: controller-refactor-plan
+description: "Analyze one controller file, determine which handlers are no longer wired from routes, and assess whether controller responsibilities have grown beyond validation/response orchestration. Produce analysis only (no implementation plan). Use this when the user says 'analyze this controller', 'is this controller still used', 'find dead controller handlers', or 'does this controller do too much'."
+argument-hint: "[path to controller file] [optional output markdown path]"
+---
+
+# Controller Analysis
+
+Use this skill to audit a single controller in `firstwho-app` and produce an analysis document. The analysis answers three questions: which controller handlers are still reachable from routes, where controller code exceeds controller scope, and what context boundaries are implicated. This skill is analysis-only and does not propose implementation sequencing.
+
+## Arguments
+
+- `$1` - Required. Path to a controller file, usually under `app/controllers/` (example: `app/controllers/orders/orders-controller.js`).
+- `$2` - Optional. Output path for the markdown analysis. If omitted, write to `docs/<controller-name>-analysis.md`.
+
+## Before Starting
+
+1. Confirm you are in repo root and `AGENTS.md` exists.
+2. Confirm `$1` exists and is a file.
+3. Set defaults:
+
+```bash
+controller_path="$1"
+controller_name="$(basename "$controller_path" .js)"
+output_path="${2:-docs/${controller_name}-analysis.md}"
+mkdir -p "$(dirname "$output_path")"
+```
+
+4. Normalize controller import key for route lookups:
+
+```bash
+controller_rel="${controller_path#app/controllers/}"
+controller_no_ext="${controller_rel%.js}"
+```
+
+## Steps
+
+### 1. Build a route reachability map
+
+Find where this controller is imported and where its handlers are used in routing.
+
+```bash
+rg -n "controllers/${controller_no_ext}(\\.js)?" app/routes
+```
+
+Then read each matching route file (always include `app/routes/backend-routes.js`) and build a table:
+
+- Import style (`default import`, `named import`, `alias import`)
+- Handler symbol in route (`controller.method` or direct function)
+- HTTP verb + path
+
+**Pattern reference:** Route wiring style is defined in `app/routes/backend-routes.js` with both default-object handlers (for example `calibrate.updateProfile`) and named imports (for example `createPaymentIntent as ordersCreatePaymentIntent` from `app/controllers/orders/orders-controller.js`).
+
+### 2. Enumerate controller handlers exported by the file
+
+Extract all handlers this controller makes externally reachable.
+
+```bash
+rg -n "export const [A-Za-z0-9_]+\s*=|export default\s*\{" "$controller_path"
+```
+
+Also inspect inline handler definitions in default exports:
+
+```bash
+rg -n "^[[:space:]]*[A-Za-z0-9_]+:\s*async\s*\(|^[[:space:]]*[A-Za-z0-9_]+:\s*\(" "$controller_path"
+```
+
+Create a handler inventory table:
+
+- Handler name
+- Export mode (`named` or `default object`)
+- Route references found in Step 1
+- Reachability status (`active`, `possibly-unused`, `indirect/unknown`)
+
+Treat handlers with no route references as `possibly-unused` until a repo-wide search confirms no non-router callers:
+
+```bash
+handler_name="<handler>"
+rg -n "\\b${handler_name}\\b" app
+```
+
+### 3. Score controller responsibility boundaries
+
+Audit whether handlers are mainly orchestration or contain domain logic that belongs in contexts.
+
+Use fast signals:
+
+```bash
+rg -n "from \"\.\./\.\./models|from \"\.\./models|from \"\.\./\.\./libraries/nodejs-manager/src/libraries/db-conn|from \"\.\./libraries/nodejs-manager/src/libraries/db-conn|\.transaction\(|await db\." "$controller_path"
+rg -n "from \"\.\./\.\./contexts|from \"\.\./contexts" "$controller_path"
+rg -n "new Stripe|new OpenAI|S3Client|axios|fetch\(" "$controller_path"
+```
+
+For each handler, classify responsibilities:
+
+- `controller-appropriate`: request/session validation, auth gate, selecting status code, `renderPage/jsonResponse`.
+- `should-live-in-context`: model queries, transactions, business rule branching, third-party orchestration, heavy data shaping.
+
+**Pattern reference (healthy split):** `app/controllers/community/calibrate-controller.js` keeps route handlers thin and delegates business logic to `app/contexts/calibrate.js`.
+
+**Pattern reference (scope creep example):** `app/controllers/community/community-resources-controller.js` and large managers such as `app/controllers/opportunities/opportunities-job-manager.js` include substantial model/data logic directly in controllers.
+
+### 4. Map logic to existing contexts
+
+Prefer reusing existing contexts where themes already exist.
+
+1. List likely context candidates by domain keyword from the controller name and imports.
+2. Inspect matching context files under `app/contexts/`.
+3. Decide for each extracted responsibility:
+
+- `move to existing context` (name the exact file)
+- `create new context` (propose exact path and thematic scope)
+
+Guideline for new context creation: only add a new file when responsibilities do not fit existing context boundaries.
+
+### 5. Produce an analysis markdown
+
+Write the plan to `$output_path` using this structure:
+
+```markdown
+# Controller Analysis: <controller path>
+
+## 1. Route Reachability
+| Handler | Export | Route(s) | Status |
+| --- | --- | --- | --- |
+
+## 2. Findings: Controller Scope
+- <finding with file/line references>
+
+## 3. Dead or Orphaned Handlers
+- <handler> - <evidence>
+
+## 4. Context Boundary Analysis
+- Existing contexts related to controller concerns
+- Responsibilities currently in controller that align with those contexts
+- Responsibilities with no clear existing context home
+
+## 5. Risk + Test Surface
+- Behavior risks
+- Regression checks
+- Existing tests and apparent gaps in `app/test/controllers/` and `app/test/contexts/`
+```
+
+### 6. Keep output strictly analytical
+
+Do not include:
+
+- step-by-step implementation plans
+- PR sequencing
+- explicit code-change instructions
+- specific function-by-function rewrite directives
+
+You may include observations such as:
+
+- "likely extraction candidate"
+- "possibly dead route handler"
+- "responsibility appears split across controller and context"
+
+but keep them evidence-based and non-prescriptive.
+
+## Conventions
+
+- Routes are explicitly wired in `app/routes/backend-routes.js`; there is no auto-registration.
+- Controllers should remain thin: validate request/session, call contexts, and return page/API output.
+- Contexts own domain orchestration, model access, and data transforms (see `app/contexts/calibrate.js` and `app/contexts/orders.js`).
+- Keep tests in `app/test/` (not adjacent to implementation).
+- If route usage is ambiguous, mark as `indirect/unknown` and show search evidence instead of guessing.

--- a/skills/dev-workflow/SKILL.md
+++ b/skills/dev-workflow/SKILL.md
@@ -14,12 +14,12 @@ If any phase fails, stop and report which phase failed and why. Do not proceed t
 ## Phase 1: Spec
 
 If an issue number is provided ($ARGUMENTS):
-1. Follow `skills/spec/SKILL.md` to write a spec.
+1. Follow `~/.agents/skills/spec/SKILL.md` to write a spec.
 2. Write the spec to the existing issue: `gh issue edit <issue-number> --body '<spec body>'`.
 3. Capture the issue number for all subsequent phases.
 
 If no issue number is provided:
-1. Follow `skills/spec/SKILL.md` to write a spec and create a new GitHub issue.
+1. Follow `~/.agents/skills/spec/SKILL.md` to write a spec and create a new GitHub issue.
 2. Capture the new issue number for all subsequent phases.
 
 ## Phase 2: Review
@@ -87,41 +87,117 @@ After codex returns:
 5. If `spec_modified` is `true`, proceed (the issue body is already updated).
 6. Continue to Phase 3 only when `review_status=success` and `viable=true`.
 
-## Phase 3: Branch
+## Phase 3: Branch + Worktree
 
-Follow `skills/branch/SKILL.md` with the issue number.
+Create an isolated worktree so multiple dev-workflows can run concurrently against the same repository, each in its own VSCode window.
 
 1. Read the GitHub issue to understand the topic.
-2. Create a descriptive branch name that includes the issue number.
-3. Check out the new branch.
+2. Derive a descriptive slug from the issue title (e.g., `42-add-auth-middleware`).
+   The slug must include the issue number and be a valid branch name.
+3. Extract the repository name from `git remote get-url origin` (last path segment, strip `.git` suffix).
+4. Check for existing worktree/branch (enables re-entry after a crashed run):
+   - If `~/.worktrees/<repo-name>/<slug>` already exists, reuse it and skip to step 6.
+   - If branch `<slug>` exists but no worktree, run:
+     `git worktree add ~/.worktrees/<repo-name>/<slug> <slug>`
+   - If neither exists, create both from the latest remote main:
+     ```bash
+     git fetch origin
+     mkdir -p ~/.worktrees/<repo-name>
+     git worktree add ~/.worktrees/<repo-name>/<slug> -b <slug> origin/main
+     ```
+5. Record the absolute worktree path. All subsequent phases operate from this path.
+6. Copy environment files from the original repository root into the worktree:
+   ```bash
+   cp .env ~/.worktrees/<repo-name>/<slug>/.env
+   ```
+   If `.env` does not exist in the source repo, skip this step without failing.
+7. Color-code the VSCode window. Compute the color index as `<issue-number> % 8` and select the hex value from this palette:
 
-## Phase 4: Implement
+   | Index | Color  | Hex       |
+   |-------|--------|-----------|
+   | 0     | Teal   | `#0d7377` |
+   | 1     | Purple | `#6a1b9a` |
+   | 2     | Orange | `#e65100` |
+   | 3     | Blue   | `#1565c0` |
+   | 4     | Green  | `#2e7d32` |
+   | 5     | Red    | `#b71c1c` |
+   | 6     | Indigo | `#283593` |
+   | 7     | Brown  | `#4e342e` |
 
-Delegate implementation to a subagent that follows `skills/run-agents/SKILL.md`:
+   Write `.vscode/settings.json` in the worktree with the color settings:
+   - If no `.vscode/settings.json` exists, write:
+     ```json
+     {
+       "workbench.colorCustomizations": {
+         "titleBar.activeBackground": "<hex>",
+         "titleBar.activeForeground": "#ffffff",
+         "statusBar.background": "<hex>",
+         "statusBar.foreground": "#ffffff"
+       }
+     }
+     ```
+   - If `.vscode/settings.json` already exists, merge via `jq`:
+     ```bash
+     jq --arg bg "<hex>" \
+       '.["workbench.colorCustomizations"] = {"titleBar.activeBackground": $bg, "titleBar.activeForeground": "#ffffff", "statusBar.background": $bg, "statusBar.foreground": "#ffffff"}' \
+       .vscode/settings.json > /tmp/vscode-settings-tmp.json && mv /tmp/vscode-settings-tmp.json .vscode/settings.json
+     ```
+   - If `jq` is not available, write the file from scratch (color settings only).
+8. Write a continuation hook so the new VSCode window's Claude Code session automatically receives the next-phase instructions on startup.
 
-```txt
-Agent(
-  subagent_type: "general-purpose",
-  description: "Implement issue #<issue-number> all steps",
-  prompt: "Follow skills/run-agents/SKILL.md to implement all steps from GitHub issue #<issue-number>.
-Read the issue spec via gh issue view <issue-number> --json body --jq '.body'.
-Implement each step with a dedicated subagent. Commit after each verified step.
-Report per-step completion with commit hashes when done."
-)
-```
+   Create `<worktree-path>/.claude/hooks/continue.sh`:
 
-After the subagent returns, verify that all steps completed successfully. If the subagent reports blockers, stop and report them.
+   ```bash
+   #!/bin/bash
+   cat <<'PROMPT'
+   # Continue Dev Workflow — Issue #<issue-number>
 
-## Phase 5: PR
+   This worktree was created by the dev-workflow skill. Pick up from Phase 4.
 
-Follow `skills/pr/SKILL.md` with the issue number.
+   ## Phase 4: Implement
 
-1. Read the GitHub issue to understand the context.
-2. Commit any remaining staged files with a conventional commit.
-3. Push the branch to origin.
-4. Open a pull request:
-   - Title: short, imperative, under 70 characters.
-   - Body: summary of what changed and why, link to the issue.
-   - Reference and close the issue.
+   Follow `~/.agents/skills/run-agents/SKILL.md` to implement all steps from GitHub issue #<issue-number>.
+   Read the issue spec via `gh issue view <issue-number> --json body --jq '.body'`.
+   Implement each step with a dedicated subagent. Commit after each verified step.
 
-Do not add Co-Authored-By trailers, "Generated with" footers, or any AI model attribution.
+   ## Phase 5: PR
+
+   Follow `~/.agents/skills/pr/SKILL.md` with issue number <issue-number>.
+
+   1. Read the GitHub issue to understand the context.
+   2. Commit any remaining staged files with a conventional commit.
+   3. Push the branch to origin: `git push -u origin <slug>`.
+   4. Open a pull request:
+      - Title: short, imperative, under 70 characters.
+      - Body: summary of what changed and why, link to the issue.
+      - Reference and close the issue.
+   Do not add Co-Authored-By trailers, "Generated with" footers, or any AI model attribution.
+   PROMPT
+   ```
+
+   Make it executable: `chmod +x <worktree-path>/.claude/hooks/continue.sh`
+
+   Write `<worktree-path>/.claude/settings.json` (merge with existing if present):
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         {
+           "matcher": "startup",
+           "hooks": [
+             {
+               "type": "command",
+               "command": ".claude/hooks/continue.sh",
+               "timeout": 10
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+9. Open the worktree in a new VSCode window: `code --new-window ~/.worktrees/<repo-name>/<slug>`
+
+10. **STOP.** Do not proceed to implementation. Report the worktree path, issue number, and branch name to the user. The new VSCode window's Claude Code session will receive the continuation prompt via the SessionStart hook — the user just needs to type "go".


### PR DESCRIPTION
## Summary
- Rewrite dev-workflow Phase 3 to use git worktrees (`~/.worktrees/<repo>/<slug>`), enabling concurrent isolated runs each in their own VSCode window with color-coded title/status bars and SessionStart continuation hooks.
- Update skill path references from relative to absolute (`~/.agents/skills/...`).
- Add new `controller-refactor-plan` skill for auditing controller scope, dead handlers, and responsibility creep.

## Test plan
- [ ] Run dev-workflow end-to-end and verify worktree is created under `~/.worktrees/`
- [ ] Confirm `.vscode/settings.json` color-coding is applied in the new window
- [ ] Confirm `.claude/hooks/continue.sh` is written and executable
- [ ] Open the worktree in VSCode and verify the SessionStart hook delivers the continuation prompt
- [ ] Run `controller-refactor-plan` skill against a sample controller and verify analysis output

Closes #1