### PR TITLE
Add decomposition-first AGENTS docs pipeline (Phase 1-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .DS_Store
 tmp/
+.specs/

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -205,11 +205,13 @@ fix:
   silenced by being
   set aside. A reviewer may still re-raise a suppressed dismissal it disagrees with,
   clearly marked, so genuine disagreement surfaces.
-- **Artifacts are always committed.** They are product, not scratch — iteration
-  memory, dismissal memory, and the audit trail. The fix skill commits the
-  review+fix pair (a `chore(reviews):` commit when there is no code change); the loop
-  driver commits the trailing review on any terminal stop — clean, cap, or stalled.
-  The read-only reviewer never commits.
+- **Artifacts are always written, but never force-added.** They are product, not
+  scratch — iteration memory, dismissal memory, and the audit trail. The fix skill
+  commits the review+fix pair only when those files are already tracked or not
+  ignored by Git; the loop driver follows the same rule for the trailing review on
+  any terminal stop — clean, cap, or stalled. If `.specs/` is ignored and the only
+  changes are untracked review artifacts, leave them local and report that no
+  artifact commit was made. The read-only reviewer never commits.
 
 ---
 

--- a/scripts/decompose-skeleton.mjs
+++ b/scripts/decompose-skeleton.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 const IGNORED_DIRS = new Set([
@@ -186,13 +187,39 @@ function computeCoverage(repoRoot, targets, lowConfidence) {
   return { unassigned, overlaps, low_confidence: lowConfidence };
 }
 
+function sha256(contents) {
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+export function sourceHash(repoRoot, globs) {
+  const entries = walkSourceFiles(repoRoot)
+    .filter((file) => globs.some((g) => matches(file, g)))
+    .map((file) => `${file}\0${sha256(fs.readFileSync(path.join(repoRoot, file)))}`)
+    .sort((a, b) => a.localeCompare(b));
+  return "sha256:" + sha256(entries.join("\n"));
+}
+
+function reconcile(targets, manifest) {
+  const prior = new Map(manifest.targets.map((t) => [t.slug, t]));
+  for (const target of targets) {
+    const carry = prior.get(target.slug);
+    if (!carry) continue;
+    target.name = carry.name;
+    target.scope = carry.scope;
+    target.last_synthesized = carry.last_synthesized;
+  }
+}
+
 export function derive(repoRoot, { manifest } = {}) {
   if (!repoRoot) throw new Error("repoRoot is required");
   if (!isDir(repoRoot)) throw new Error(`not a directory: ${repoRoot}`);
-  void manifest;
 
   const { units, lowConfidence } = detectUnits(repoRoot);
   const targets = buildTargets(units);
+  for (const target of targets) {
+    target.source_hash = sourceHash(repoRoot, target.source_globs);
+  }
+  if (manifest) reconcile(targets, manifest);
   const coverage = computeCoverage(repoRoot, targets, lowConfidence);
 
   return {
@@ -205,14 +232,43 @@ export function derive(repoRoot, { manifest } = {}) {
   };
 }
 
+function parseArgs(argv) {
+  const args = { repoRoot: argv[2], manifestPath: null };
+  for (let i = 3; i < argv.length; i++) {
+    if (argv[i] === "--manifest") {
+      args.manifestPath = argv[++i];
+      if (!args.manifestPath) throw new Error("--manifest requires a path");
+    } else {
+      throw new Error(`unknown argument: ${argv[i]}`);
+    }
+  }
+  return args;
+}
+
 function main() {
-  const repoRoot = process.argv[2];
-  if (!repoRoot) {
-    console.error("usage: node scripts/decompose-skeleton.mjs <repo-root>");
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    console.error(err.message);
     process.exit(1);
   }
-  const manifest = derive(path.resolve(repoRoot));
-  console.log(JSON.stringify(manifest, null, 2));
+  if (!args.repoRoot) {
+    console.error("usage: node scripts/decompose-skeleton.mjs <repo-root> [--manifest <path>]");
+    process.exit(1);
+  }
+
+  let manifest;
+  if (args.manifestPath) {
+    if (!fs.existsSync(args.manifestPath)) {
+      console.error(`manifest not found: ${args.manifestPath}`);
+      process.exit(1);
+    }
+    manifest = readJson(args.manifestPath);
+  }
+
+  const result = derive(path.resolve(args.repoRoot), { manifest });
+  console.log(JSON.stringify(result, null, 2));
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {

--- a/scripts/decompose-skeleton.mjs
+++ b/scripts/decompose-skeleton.mjs
@@ -1,0 +1,220 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const IGNORED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "target",
+  "out",
+  "coverage",
+  "tmp",
+  ".specs",
+  "tests",
+  "test",
+  "__tests__",
+  "__mocks__",
+  "docs",
+  ".github",
+]);
+
+const IGNORED_FILES = new Set([".DS_Store"]);
+
+const SOURCE_ROOTS = ["src", "lib", "app", "packages", "services", "cmd"];
+
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+function childDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !IGNORED_DIRS.has(e.name))
+    .map((e) => e.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function walkSourceFiles(repoRoot) {
+  const files = [];
+  const recurse = (absDir, relDir) => {
+    for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRS.has(entry.name)) continue;
+        recurse(path.join(absDir, entry.name), relDir ? `${relDir}/${entry.name}` : entry.name);
+      } else if (entry.isFile()) {
+        if (IGNORED_FILES.has(entry.name)) continue;
+        files.push(relDir ? `${relDir}/${entry.name}` : entry.name);
+      }
+    }
+  };
+  recurse(repoRoot, "");
+  return files;
+}
+
+function matches(relPath, glob) {
+  if (glob === "**") return true;
+  if (glob.endsWith("/**")) {
+    const prefix = glob.slice(0, -3);
+    return relPath === prefix || relPath.startsWith(`${prefix}/`);
+  }
+  throw new Error(`unsupported glob shape: ${glob}`);
+}
+
+function slugify(p) {
+  if (p === ".") return "root";
+  const slug = p
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "root";
+}
+
+function uniqueSlug(structuralUnit, taken) {
+  let base = slugify(structuralUnit);
+  if (!taken.has(base)) return base;
+
+  const segments = structuralUnit === "." ? [] : structuralUnit.split("/");
+  let candidate = base;
+  for (let i = segments.length - 2; i >= 0; i--) {
+    candidate = `${slugify(segments[i])}-${candidate}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  let n = 2;
+  while (taken.has(`${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function workspaceGlobs(repoRoot) {
+  const globs = [];
+  const pkgPath = path.join(repoRoot, "package.json");
+  if (fs.existsSync(pkgPath)) {
+    const ws = readJson(pkgPath).workspaces;
+    if (Array.isArray(ws)) globs.push(...ws);
+    else if (ws && Array.isArray(ws.packages)) globs.push(...ws.packages);
+  }
+  const pnpmPath = path.join(repoRoot, "pnpm-workspace.yaml");
+  if (fs.existsSync(pnpmPath)) globs.push(...parsePnpmPackages(pnpmPath));
+  return globs;
+}
+
+function parsePnpmPackages(pnpmPath) {
+  const lines = fs.readFileSync(pnpmPath, "utf8").split("\n");
+  const packages = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (/^packages:\s*$/.test(line)) {
+      inBlock = true;
+      continue;
+    }
+    if (!inBlock) continue;
+    const item = line.match(/^\s+-\s+['"]?([^'"\n]+?)['"]?\s*$/);
+    if (item) packages.push(item[1]);
+    else if (line.trim() !== "") break;
+  }
+  return packages;
+}
+
+function resolveWorkspaceUnits(repoRoot, globs) {
+  const units = new Set();
+  for (const glob of globs) {
+    if (glob.endsWith("/*")) {
+      const parent = glob.slice(0, -2);
+      for (const child of childDirs(path.join(repoRoot, parent))) {
+        const rel = parent ? `${parent}/${child}` : child;
+        if (fs.existsSync(path.join(repoRoot, rel, "package.json"))) units.add(rel);
+      }
+    } else if (!glob.includes("*")) {
+      if (fs.existsSync(path.join(repoRoot, glob, "package.json"))) units.add(glob);
+    }
+  }
+  return [...units];
+}
+
+function detectUnits(repoRoot) {
+  const wsUnits = resolveWorkspaceUnits(repoRoot, workspaceGlobs(repoRoot));
+  if (wsUnits.length) return { units: wsUnits, lowConfidence: false };
+
+  for (const root of SOURCE_ROOTS) {
+    if (isDir(path.join(repoRoot, root))) {
+      const children = childDirs(path.join(repoRoot, root));
+      if (children.length) return { units: children.map((c) => `${root}/${c}`), lowConfidence: false };
+    }
+  }
+
+  const topLevel = childDirs(repoRoot);
+  if (topLevel.length) return { units: topLevel, lowConfidence: false };
+
+  return { units: ["."], lowConfidence: true };
+}
+
+function buildTargets(unitPaths) {
+  const sorted = [...unitPaths].sort((a, b) => a.localeCompare(b));
+  const taken = new Set();
+  return sorted.map((unit) => {
+    const slug = uniqueSlug(unit, taken);
+    taken.add(slug);
+    return {
+      slug,
+      name: "",
+      scope: "",
+      origin: "derived",
+      structural_unit: unit,
+      source_globs: unit === "." ? ["**"] : [`${unit}/**`],
+      tier2_path: `docs/specops/analysis/${slug}.md`,
+      source_hash: null,
+      last_synthesized: null,
+    };
+  });
+}
+
+function computeCoverage(repoRoot, targets, lowConfidence) {
+  const unassigned = [];
+  const overlaps = [];
+  for (const file of walkSourceFiles(repoRoot)) {
+    const owners = targets.filter((t) => t.source_globs.some((g) => matches(file, g)));
+    if (owners.length === 0) unassigned.push(file);
+    else if (owners.length > 1) overlaps.push({ path: file, slugs: owners.map((t) => t.slug) });
+  }
+  unassigned.sort((a, b) => a.localeCompare(b));
+  return { unassigned, overlaps, low_confidence: lowConfidence };
+}
+
+export function derive(repoRoot, { manifest } = {}) {
+  if (!repoRoot) throw new Error("repoRoot is required");
+  if (!isDir(repoRoot)) throw new Error(`not a directory: ${repoRoot}`);
+  void manifest;
+
+  const { units, lowConfidence } = detectUnits(repoRoot);
+  const targets = buildTargets(units);
+  const coverage = computeCoverage(repoRoot, targets, lowConfidence);
+
+  return {
+    version: 1,
+    system: { summary: "", external_dependencies: [] },
+    targets,
+    overrides: [],
+    renames: [],
+    coverage,
+  };
+}
+
+function main() {
+  const repoRoot = process.argv[2];
+  if (!repoRoot) {
+    console.error("usage: node scripts/decompose-skeleton.mjs <repo-root>");
+    process.exit(1);
+  }
+  const manifest = derive(path.resolve(repoRoot));
+  console.log(JSON.stringify(manifest, null, 2));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/scripts/decompose-skeleton.mjs
+++ b/scripts/decompose-skeleton.mjs
@@ -322,12 +322,133 @@ export function derive(repoRoot, { manifest } = {}) {
   };
 }
 
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value !== "";
+}
+
+const TARGET_FIELD_SPECS = [
+  { field: "slug", type: "non-empty string", ok: isNonEmptyString },
+  { field: "name", type: "string", ok: (v) => typeof v === "string" },
+  { field: "scope", type: "string", ok: (v) => typeof v === "string" },
+  { field: "origin", type: '"derived" or "override"', ok: (v) => v === "derived" || v === "override" },
+  { field: "structural_unit", type: "non-empty string", ok: isNonEmptyString },
+  {
+    field: "source_globs",
+    type: "non-empty array of strings",
+    ok: (v) => Array.isArray(v) && v.length >= 1 && v.every((g) => typeof g === "string"),
+  },
+  { field: "tier2_path", type: "string", ok: (v) => typeof v === "string" },
+  { field: "source_hash", type: "string or null", ok: (v) => v === null || typeof v === "string" },
+  { field: "last_synthesized", type: "string or null", ok: (v) => v === null || typeof v === "string" },
+];
+
+function validateSchema(manifest, violations) {
+  if (typeof manifest.version !== "number") violations.push("version must be a number");
+  if (!isObject(manifest.system)) violations.push("system must be an object");
+  if (!Array.isArray(manifest.targets)) violations.push("targets must be an array");
+  if (!Array.isArray(manifest.overrides)) violations.push("overrides must be an array");
+  if (!Array.isArray(manifest.renames)) violations.push("renames must be an array");
+  if (!isObject(manifest.coverage)) violations.push("coverage is required");
+
+  if (!Array.isArray(manifest.targets)) return;
+
+  manifest.targets.forEach((target, i) => {
+    const label = isNonEmptyString(target?.slug) ? `slug ${target.slug}` : `target[${i}]`;
+    for (const spec of TARGET_FIELD_SPECS) {
+      if (!spec.ok(target?.[spec.field])) {
+        violations.push(`${label} ${spec.field} must be ${spec.type}`);
+      }
+    }
+  });
+
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const target of manifest.targets) {
+    if (!isNonEmptyString(target?.slug)) continue;
+    if (seen.has(target.slug)) duplicates.add(target.slug);
+    seen.add(target.slug);
+  }
+  for (const slug of duplicates) violations.push(`duplicate slug: ${slug}`);
+}
+
+function validateGlobsResolve(repoRoot, manifest, violations) {
+  if (!Array.isArray(manifest.targets)) return;
+  const files = walkSourceFiles(repoRoot);
+  for (const target of manifest.targets) {
+    if (!Array.isArray(target?.source_globs)) continue;
+    const slug = isNonEmptyString(target.slug) ? target.slug : "?";
+    for (const glob of target.source_globs) {
+      if (typeof glob !== "string") continue;
+      let resolved;
+      try {
+        resolved = files.some((file) => matches(file, glob));
+      } catch {
+        violations.push(`unsupported glob: ${glob} (slug ${slug})`);
+        continue;
+      }
+      if (!resolved) violations.push(`glob resolves to no files: ${glob} (slug ${slug})`);
+    }
+  }
+}
+
+function validateMembership(repoRoot, manifest, violations) {
+  if (!Array.isArray(manifest.targets)) return;
+  let fresh;
+  try {
+    fresh = derive(repoRoot, { manifest });
+  } catch (err) {
+    violations.push(`derivation failed: ${err.message}`);
+    return;
+  }
+  const freshBySlug = new Map(fresh.targets.map((t) => [t.slug, t]));
+  for (const target of manifest.targets) {
+    const derived = freshBySlug.get(target?.slug);
+    if (!derived) continue;
+    if (target.structural_unit !== derived.structural_unit) {
+      violations.push(
+        `structural_unit mismatch for ${target.slug}: manifest=${target.structural_unit} derived=${derived.structural_unit}`
+      );
+    }
+    if (JSON.stringify(target.source_globs) !== JSON.stringify(derived.source_globs)) {
+      violations.push(
+        `source_globs mismatch for ${target.slug}: manifest=${JSON.stringify(target.source_globs)} derived=${JSON.stringify(derived.source_globs)}`
+      );
+    }
+  }
+}
+
+export function check(repoRoot, manifestPath) {
+  if (!repoRoot) throw new Error("repoRoot is required");
+  if (!isDir(repoRoot)) throw new Error(`not a directory: ${repoRoot}`);
+
+  let manifest;
+  try {
+    manifest = readJson(manifestPath);
+  } catch (err) {
+    throw new Error(`cannot read manifest ${manifestPath}: ${err.message}`);
+  }
+
+  const violations = [];
+  validateSchema(manifest, violations);
+  validateGlobsResolve(repoRoot, manifest, violations);
+  validateMembership(repoRoot, manifest, violations);
+
+  return { ok: violations.length === 0, violations };
+}
+
 function parseArgs(argv) {
-  const args = { repoRoot: argv[2], manifestPath: null };
+  const args = { repoRoot: argv[2], manifestPath: null, checkPath: null };
   for (let i = 3; i < argv.length; i++) {
     if (argv[i] === "--manifest") {
       args.manifestPath = argv[++i];
       if (!args.manifestPath) throw new Error("--manifest requires a path");
+    } else if (argv[i] === "--check") {
+      args.checkPath = argv[++i];
+      if (!args.checkPath) throw new Error("--check requires a path");
     } else {
       throw new Error(`unknown argument: ${argv[i]}`);
     }
@@ -344,8 +465,22 @@ function main() {
     process.exit(1);
   }
   if (!args.repoRoot) {
-    console.error("usage: node scripts/decompose-skeleton.mjs <repo-root> [--manifest <path>]");
+    console.error(
+      "usage: node scripts/decompose-skeleton.mjs <repo-root> [--manifest <path>] | --check <path>"
+    );
     process.exit(1);
+  }
+
+  if (args.checkPath) {
+    let result;
+    try {
+      result = check(path.resolve(args.repoRoot), args.checkPath);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    for (const violation of result.violations) console.error(violation);
+    process.exit(result.ok ? 0 : 1);
   }
 
   let manifest;

--- a/scripts/decompose-skeleton.mjs
+++ b/scripts/decompose-skeleton.mjs
@@ -175,6 +175,81 @@ function buildTargets(unitPaths) {
   });
 }
 
+function overrideTarget(slug, structuralUnit, sourceGlobs) {
+  return {
+    slug,
+    name: "",
+    scope: "",
+    origin: "override",
+    structural_unit: structuralUnit,
+    source_globs: sourceGlobs,
+    tier2_path: `docs/specops/analysis/${slug}.md`,
+    source_hash: null,
+    last_synthesized: null,
+  };
+}
+
+function findUnit(targets, unitPath, op) {
+  const target = targets.find((t) => t.structural_unit === unitPath);
+  if (!target) throw new Error(`override ${op} references unknown unit: ${unitPath}`);
+  return target;
+}
+
+function applyMerge(targets, override) {
+  const members = override.units.map((unit) => findUnit(targets, unit, "merge"));
+  const memberSet = new Set(members);
+  const union = [...new Set(members.flatMap((t) => t.source_globs))].sort((a, b) => a.localeCompare(b));
+  const remaining = targets.filter((t) => !memberSet.has(t));
+  return [...remaining, overrideTarget(override.into, override.into, union)];
+}
+
+function applySplit(targets, override) {
+  const parent = findUnit(targets, override.unit, "split");
+  const children = override.into.map((child) =>
+    overrideTarget(child.slug, child.subpath, [`${child.subpath}/**`])
+  );
+  const remaining = targets.filter((t) => t !== parent);
+  return [...remaining, ...children];
+}
+
+function applyRelabel(targets, override) {
+  const target = findUnit(targets, override.unit, "relabel");
+  target.name = override.name;
+  target.scope = override.scope;
+  target.origin = "override";
+  return targets;
+}
+
+function applyOverrides(targets, overrides) {
+  let current = targets;
+  for (const override of overrides) {
+    if (override.op === "merge") current = applyMerge(current, override);
+    else if (override.op === "split") current = applySplit(current, override);
+    else if (override.op === "relabel") current = applyRelabel(current, override);
+    else throw new Error(`override op unknown: ${override.op}`);
+  }
+  return current;
+}
+
+function detectRenames(freshTargets, manifest) {
+  const priorSlugs = new Set(manifest.targets.map((t) => t.slug));
+  const freshSlugs = new Set(freshTargets.map((t) => t.slug));
+  const newTargets = [...freshTargets]
+    .filter((t) => !priorSlugs.has(t.slug))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+  const consumed = new Set();
+
+  const renames = [];
+  for (const prior of manifest.targets) {
+    if (freshSlugs.has(prior.slug)) continue;
+    const match = newTargets.find((t) => !consumed.has(t.slug) && t.source_hash === prior.source_hash);
+    if (!match) continue;
+    consumed.add(match.slug);
+    renames.push({ old_slug: prior.slug, new_slug: match.slug });
+  }
+  return renames;
+}
+
 function computeCoverage(repoRoot, targets, lowConfidence) {
   const unassigned = [];
   const overlaps = [];
@@ -191,10 +266,23 @@ function sha256(contents) {
   return createHash("sha256").update(contents).digest("hex");
 }
 
+function globBase(glob) {
+  return glob === "**" ? "" : glob.replace(/\/\*\*$/, "");
+}
+
+function unitRelative(file, globs) {
+  for (const glob of globs) {
+    if (!matches(file, glob)) continue;
+    const base = globBase(glob);
+    return base === "" ? file : file.slice(base.length + 1);
+  }
+  return file;
+}
+
 export function sourceHash(repoRoot, globs) {
   const entries = walkSourceFiles(repoRoot)
     .filter((file) => globs.some((g) => matches(file, g)))
-    .map((file) => `${file}\0${sha256(fs.readFileSync(path.join(repoRoot, file)))}`)
+    .map((file) => `${unitRelative(file, globs)}\0${sha256(fs.readFileSync(path.join(repoRoot, file)))}`)
     .sort((a, b) => a.localeCompare(b));
   return "sha256:" + sha256(entries.join("\n"));
 }
@@ -215,19 +303,21 @@ export function derive(repoRoot, { manifest } = {}) {
   if (!isDir(repoRoot)) throw new Error(`not a directory: ${repoRoot}`);
 
   const { units, lowConfidence } = detectUnits(repoRoot);
-  const targets = buildTargets(units);
+  const overrides = manifest?.overrides ?? [];
+  const targets = applyOverrides(buildTargets(units), overrides);
   for (const target of targets) {
     target.source_hash = sourceHash(repoRoot, target.source_globs);
   }
   if (manifest) reconcile(targets, manifest);
+  const renames = manifest ? detectRenames(targets, manifest) : [];
   const coverage = computeCoverage(repoRoot, targets, lowConfidence);
 
   return {
     version: 1,
     system: { summary: "", external_dependencies: [] },
     targets,
-    overrides: [],
-    renames: [],
+    overrides,
+    renames,
     coverage,
   };
 }

--- a/scripts/decompose-skeleton.test.mjs
+++ b/scripts/decompose-skeleton.test.mjs
@@ -6,6 +6,10 @@ import path from "node:path";
 
 import { derive } from "./decompose-skeleton.mjs";
 
+function apiTarget(manifest) {
+  return manifest.targets.find((t) => t.structural_unit === "packages/api");
+}
+
 const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 function makeTempRepo() {
@@ -96,6 +100,64 @@ test("a repo with no detectable module system yields one low-confidence root uni
     assert.equal(manifest.targets.length, 1);
     assert.equal(manifest.targets[0].structural_unit, ".");
     assert.equal(manifest.coverage.low_confidence, true);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("source_hash is unchanged after an mtime-only touch of a matched file", () => {
+  const repo = workspaceRepo();
+  try {
+    const before = apiTarget(derive(repo)).source_hash;
+
+    const matched = path.join(repo, "packages/api/index.js");
+    const future = new Date("2030-01-01T00:00:00Z");
+    fs.utimesSync(matched, future, future);
+
+    const after = apiTarget(derive(repo)).source_hash;
+
+    assert.equal(after, before);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("source_hash changes after a content edit of a matched file", () => {
+  const repo = workspaceRepo();
+  try {
+    const before = apiTarget(derive(repo)).source_hash;
+
+    write(repo, "packages/api/index.js", "export const api = 2;");
+
+    const after = apiTarget(derive(repo)).source_hash;
+
+    assert.notEqual(after, before);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("reconcile preserves curated name/scope/last_synthesized and recomputes source_hash", () => {
+  const repo = workspaceRepo();
+  try {
+    const existing = derive(repo);
+    const apiSlug = apiTarget(existing).slug;
+    const curated = existing.targets.find((t) => t.slug === apiSlug);
+    curated.name = "API Service";
+    curated.scope = "Handles inbound API requests";
+    curated.last_synthesized = "2025-01-15T00:00:00Z";
+    curated.source_hash = "sha256:stale";
+
+    write(repo, "packages/api/index.js", "export const api = 3;");
+    const reconciled = derive(repo, { manifest: existing });
+    const result = reconciled.targets.find((t) => t.slug === apiSlug);
+    const freshHash = derive(repo).targets.find((t) => t.slug === apiSlug).source_hash;
+
+    assert.equal(result.name, "API Service");
+    assert.equal(result.scope, "Handles inbound API requests");
+    assert.equal(result.last_synthesized, "2025-01-15T00:00:00Z");
+    assert.equal(result.source_hash, freshHash);
+    assert.deepEqual(result.source_globs, ["packages/api/**"]);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/decompose-skeleton.test.mjs
+++ b/scripts/decompose-skeleton.test.mjs
@@ -1,0 +1,102 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { derive } from "./decompose-skeleton.mjs";
+
+const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function makeTempRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "decompose-"));
+}
+
+function write(repo, relPath, contents) {
+  const abs = path.join(repo, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function workspaceRepo() {
+  const repo = makeTempRepo();
+  write(repo, "package.json", JSON.stringify({ workspaces: ["packages/*"] }));
+  write(repo, "packages/api/package.json", "{}");
+  write(repo, "packages/api/index.js", "export const api = 1;");
+  write(repo, "packages/web/package.json", "{}");
+  write(repo, "packages/web/main.js", "export const web = 1;");
+  write(repo, "README.md", "# root");
+  return repo;
+}
+
+function projection(manifest) {
+  return manifest.targets.map((t) => ({
+    slug: t.slug,
+    structural_unit: t.structural_unit,
+    source_globs: t.source_globs,
+  }));
+}
+
+test("derive produces identical slug/structural_unit/source_globs across two runs", () => {
+  const repo = workspaceRepo();
+  try {
+    const first = derive(repo);
+    const second = derive(repo);
+
+    assert.deepEqual(projection(first), projection(second));
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("every source file is owned by exactly one target or unassigned, with no overlaps", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    const matchedFiles = ["packages/api/index.js", "packages/web/main.js"];
+
+    for (const file of matchedFiles) {
+      const owners = manifest.targets.filter((t) => t.source_globs.some((g) => g.endsWith("/**") && file.startsWith(g.slice(0, -3) + "/")));
+      assert.equal(owners.length, 1, `${file} should have exactly one owner`);
+    }
+    assert.ok(manifest.coverage.unassigned.includes("README.md"));
+    assert.deepEqual(manifest.coverage.overlaps, []);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("slugs are unique, kebab-case, and stable for a fixed structural_unit path", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    const slugs = manifest.targets.map((t) => t.slug);
+
+    assert.equal(new Set(slugs).size, slugs.length);
+    for (const slug of slugs) assert.match(slug, KEBAB);
+
+    const reran = derive(repo);
+    for (const target of manifest.targets) {
+      const same = reran.targets.find((t) => t.structural_unit === target.structural_unit);
+      assert.equal(same.slug, target.slug);
+    }
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("a repo with no detectable module system yields one low-confidence root unit", () => {
+  const repo = makeTempRepo();
+  try {
+    write(repo, "notes.txt", "loose file");
+    write(repo, "TODO.md", "loose file");
+
+    const manifest = derive(repo);
+
+    assert.equal(manifest.targets.length, 1);
+    assert.equal(manifest.targets[0].structural_unit, ".");
+    assert.equal(manifest.coverage.low_confidence, true);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/decompose-skeleton.test.mjs
+++ b/scripts/decompose-skeleton.test.mjs
@@ -162,3 +162,98 @@ test("reconcile preserves curated name/scope/last_synthesized and recomputes sou
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
+
+function singleUnitRepo() {
+  const repo = makeTempRepo();
+  write(repo, "src/alpha/index.js", "export const alpha = 1;");
+  return repo;
+}
+
+test("merge override yields one override target with union globs, surviving a second reconcile", () => {
+  const repo = workspaceRepo();
+  try {
+    const base = derive(repo);
+    base.overrides = [
+      { op: "merge", units: ["packages/api", "packages/web"], into: "platform" },
+    ];
+
+    const merged = derive(repo, { manifest: base });
+    const overrideTargets = merged.targets.filter((t) => t.origin === "override");
+
+    assert.equal(overrideTargets.length, 1);
+    assert.equal(overrideTargets[0].slug, "platform");
+    assert.deepEqual(overrideTargets[0].source_globs, ["packages/api/**", "packages/web/**"]);
+    assert.equal(merged.targets.some((t) => t.structural_unit === "packages/api"), false);
+    assert.equal(merged.targets.some((t) => t.structural_unit === "packages/web"), false);
+
+    const reconciledAgain = derive(repo, { manifest: merged });
+    const survivor = reconciledAgain.targets.find((t) => t.slug === "platform");
+
+    assert.ok(survivor);
+    assert.equal(survivor.origin, "override");
+    assert.deepEqual(survivor.source_globs, ["packages/api/**", "packages/web/**"]);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("renaming a unit dir without changing contents emits a renames entry", () => {
+  const repo = singleUnitRepo();
+  try {
+    const base = derive(repo);
+    const oldSlug = base.targets.find((t) => t.structural_unit === "src/alpha").slug;
+
+    fs.renameSync(path.join(repo, "src/alpha"), path.join(repo, "src/beta"));
+
+    const after = derive(repo, { manifest: base });
+    const newSlug = after.targets.find((t) => t.structural_unit === "src/beta").slug;
+
+    assert.deepEqual(after.renames, [{ old_slug: oldSlug, new_slug: newSlug }]);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("renaming a unit dir with content changes yields remove+add, no renames entry", () => {
+  const repo = singleUnitRepo();
+  try {
+    const base = derive(repo);
+    const oldSlug = base.targets.find((t) => t.structural_unit === "src/alpha").slug;
+
+    fs.renameSync(path.join(repo, "src/alpha"), path.join(repo, "src/beta"));
+    write(repo, "src/beta/index.js", "export const beta = 99;");
+
+    const after = derive(repo, { manifest: base });
+    const newTarget = after.targets.find((t) => t.structural_unit === "src/beta");
+
+    assert.deepEqual(after.renames, []);
+    assert.equal(after.targets.some((t) => t.slug === oldSlug), false);
+    assert.ok(newTarget);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("an unknown override op throws", () => {
+  const repo = workspaceRepo();
+  try {
+    const base = derive(repo);
+    base.overrides = [{ op: "frobnicate", unit: "packages/api" }];
+
+    assert.throws(() => derive(repo, { manifest: base }), /unknown.*frobnicate|frobnicate/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("a dangling override unit throws", () => {
+  const repo = workspaceRepo();
+  try {
+    const base = derive(repo);
+    base.overrides = [{ op: "relabel", unit: "packages/missing", name: "X", scope: "y" }];
+
+    assert.throws(() => derive(repo, { manifest: base }), /unknown unit: packages\/missing/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/decompose-skeleton.test.mjs
+++ b/scripts/decompose-skeleton.test.mjs
@@ -3,8 +3,18 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-import { derive } from "./decompose-skeleton.mjs";
+import { derive, check } from "./decompose-skeleton.mjs";
+
+const SCRIPT_PATH = fileURLToPath(new URL("./decompose-skeleton.mjs", import.meta.url));
+
+function writeManifest(repo, manifest) {
+  const manifestPath = path.join(repo, "targets.json");
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  return manifestPath;
+}
 
 function apiTarget(manifest) {
   return manifest.targets.find((t) => t.structural_unit === "packages/api");
@@ -253,6 +263,134 @@ test("a dangling override unit throws", () => {
     base.overrides = [{ op: "relabel", unit: "packages/missing", name: "X", scope: "y" }];
 
     assert.throws(() => derive(repo, { manifest: base }), /unknown unit: packages\/missing/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check passes on a script-produced manifest", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifestPath = writeManifest(repo, derive(repo));
+
+    const result = check(repo, manifestPath);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.violations, []);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check fails when source_globs is hand-edited to disagree with derivation", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    const apiSlug = apiTarget(manifest).slug;
+    apiTarget(manifest).source_globs = ["packages/web/**"];
+    const manifestPath = writeManifest(repo, manifest);
+
+    const result = check(repo, manifestPath);
+
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.violations.some((v) => v.includes("source_globs mismatch") && v.includes(apiSlug)),
+      `expected a source_globs mismatch for ${apiSlug}, got: ${JSON.stringify(result.violations)}`
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check fails when a required field is missing", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    delete manifest.coverage;
+    const manifestPath = writeManifest(repo, manifest);
+
+    const result = check(repo, manifestPath);
+
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.violations.some((v) => v.includes("coverage")),
+      `expected a coverage violation, got: ${JSON.stringify(result.violations)}`
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check fails when a slug is duplicated", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    const duplicated = manifest.targets[0];
+    manifest.targets.push({ ...duplicated });
+    const manifestPath = writeManifest(repo, manifest);
+
+    const result = check(repo, manifestPath);
+
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.violations.some((v) => v === `duplicate slug: ${duplicated.slug}`),
+      `expected a duplicate slug violation, got: ${JSON.stringify(result.violations)}`
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check fails when a source_globs entry resolves to no files", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifest = derive(repo);
+    apiTarget(manifest).source_globs = ["does/not/exist/**"];
+    const manifestPath = writeManifest(repo, manifest);
+
+    const result = check(repo, manifestPath);
+
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.violations.some((v) => v.includes("glob resolves to no files: does/not/exist/**")),
+      `expected a no-files glob violation, got: ${JSON.stringify(result.violations)}`
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("check throws a contextual error for a missing manifest file", () => {
+  const repo = workspaceRepo();
+  try {
+    assert.throws(
+      () => check(repo, path.join(repo, "no-such.json")),
+      /cannot read manifest/
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("CLI --check exits 0 on a script-produced manifest and 1 on a tampered one", () => {
+  const repo = workspaceRepo();
+  try {
+    const manifestPath = writeManifest(repo, derive(repo));
+
+    const pass = spawnSync("node", [SCRIPT_PATH, repo, "--check", manifestPath], {
+      encoding: "utf8",
+    });
+    assert.equal(pass.status, 0);
+
+    const manifest = derive(repo);
+    apiTarget(manifest).source_globs = ["does/not/exist/**"];
+    const tamperedPath = writeManifest(repo, manifest);
+
+    const fail = spawnSync("node", [SCRIPT_PATH, repo, "--check", tamperedPath], {
+      encoding: "utf8",
+    });
+    assert.equal(fail.status, 1);
+    assert.match(fail.stderr, /glob resolves to no files/);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }

--- a/skills/design-spec-writer/SKILL.md
+++ b/skills/design-spec-writer/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: design-spec-writer
-description: This skill should be used when the user asks to "write the design spec", "spec this design", "turn this design into a spec", "make the design implementable", or "write the implementation plan for this design". Creates a deterministic, design-focused implementation spec in .specs/<slug>/spec.md — the same contract spec-run consumes — from the proposal, critique, and any approved prototype.
+description: This skill should be used when the user asks to "write the design spec", "spec this design", "turn this design into a spec", "make the design implementable", or "write the implementation plan for this design". Creates a deterministic, design-focused implementation spec in .specs/<slug>/spec.md — the same contract spec-run consumes — from the proposal, critique, and any approved prototype, and automatically mirrors it to GitHub when available unless the user opts out.
 disable-model-invocation: true
 argument-hint: "[feature-slug or GitHub issue number (optional)]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Design Spec Writer
 
 Turn an approved design direction into a deterministic implementation spec that `spec-run` can execute without modification. The output is `.specs/<feature-slug>/spec.md` in the **exact same 8-section contract** the engineering `spec-write` produces — so `spec-criteria`, `spec-branch`, `spec-run`, `spec-audit`, and `spec-remediate` all work unchanged. The difference is the content: design tokens, components, states, interaction, and accessibility instead of services and data layers.
 
-The local `spec.md` is canonical; issue trackers are optional mirrors.
+The local `spec.md` is canonical; GitHub issues are automatic mirrors when available and not explicitly disabled.
 
 ## Non-Interactive Operation
 
@@ -30,7 +30,7 @@ Always write the completed spec to:
 .specs/<feature-slug>/spec.md
 ```
 
-If the current repository is a GitHub repository and `gh` is authenticated, also mirror the same spec body to a GitHub issue (edit the issue named by `$ARGUMENTS`, else create one). If GitHub is unavailable, unauthenticated, or hosted elsewhere, skip the mirror and report the local path. Bitbucket, GitLab, self-hosted, and local-only repos use `spec.md` only. (Same GitHub-mirror detection and issue-ID folder prefix rules as `spec-write`.)
+If the current repository is a GitHub repository and `gh` is authenticated, also mirror the same spec body to a GitHub issue without asking for confirmation, unless the user explicitly says not to mirror. Edit the issue named by `$ARGUMENTS`, else create one. If GitHub is unavailable, unauthenticated, hosted elsewhere, or explicitly opted out, skip the mirror and report the local path. Bitbucket, GitLab, self-hosted, and local-only repos use `spec.md` only. (Same GitHub-mirror detection and issue-ID folder prefix rules as `spec-write`.)
 
 ## Pre-Step — Load Pipeline Inputs
 

--- a/skills/spec-architect-critics/SKILL.md
+++ b/skills/spec-architect-critics/SKILL.md
@@ -3,12 +3,11 @@ name: spec-architect-critics
 description: "Critique a spec-driven architecture proposal by selecting two real-world practitioners with deep, relevant expertise and evaluating the proposal through their known perspectives. Use when the user says 'critique this architecture', 'review this proposal', 'what would an expert think of this', 'poke holes in this design', 'stress-test this approach', 'what am I missing', or 'is this a good architecture', especially after spec-architect-initial writes .specs/<slug>/proposal.md."
 mode: coding
 scope: document
-capability: repo-write
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "2"
+  version: "3"
 ---
 
 # Spec Architect Critics — Expert-Perspective Design Review

--- a/skills/spec-architect-initial/SKILL.md
+++ b/skills/spec-architect-initial/SKILL.md
@@ -3,12 +3,11 @@ name: spec-architect-initial
 description: "Act as the first architecture stage in the spec-driven workflow: given a problem or feature request, review the current system architecture and write .specs/<slug>/proposal.md with a compatible solution, or explain why the request does not fit. Use when the user says 'architect this', 'design a solution for', 'how should I implement', 'how would this fit into the codebase', 'propose an approach for', 'is this feasible in our architecture', or 'plan this feature'."
 mode: coding
 scope: document
-capability: repo-write
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "3"
+  version: "4"
 ---
 
 # Spec Architect Initial — Solution Design Against Existing Architecture

--- a/skills/spec-audit/SKILL.md
+++ b/skills/spec-audit/SKILL.md
@@ -3,14 +3,13 @@ name: spec-audit
 description: This skill should be used when the user asks to "audit the implementation against the spec", "run the spec audit", "check spec conformance", "verify the branch against the criteria", or "spec audit". Executes the frozen conformance checklist from .specs/<slug>/criteria.md against the implementation diff and reports PASS/VIOLATION/UNVERIFIABLE per criterion with file:line evidence. Report-only; never edits production code.
 mode: coding
 scope: document
-capability: shell
 disable-model-invocation: true
 argument-hint: "[feature-slug, spec path, or GitHub issue number]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "5"
+  version: "6"
 ---
 
 # Spec Audit

--- a/skills/spec-branch-fix/SKILL.md
+++ b/skills/spec-branch-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-branch-fix
-description: This skill should be used when the user or the spec-branch-refine loop asks to fix, apply, or act on a branch correctness review for one iteration — coupled to spec-branch-review only through the review file. It parses the review's YAML block, decides per finding whether to fix or dismiss (recording a dismissal class that controls re-raise suppression), applies the actionable fixes across the branch, runs tests, writes reviews/branch-<i>-fix.md, and always commits the review/fix artifacts. Trigger on "fix the branch review", "apply the branch review", "address the branch findings", or "spec branch fix".
+description: This skill should be used when the user or the spec-branch-refine loop asks to fix, apply, or act on a branch correctness review for one iteration — coupled to spec-branch-review only through the review file. It parses the review's YAML block, decides per finding whether to fix or dismiss (recording a dismissal class that controls re-raise suppression), applies the actionable fixes across the branch, runs tests, writes reviews/branch-<i>-fix.md, and commits code plus any review artifacts that are tracked or not ignored. Trigger on "fix the branch review", "apply the branch review", "address the branch findings", or "spec branch fix".
 mode: coding
 scope: document
 disable-model-invocation: true
@@ -9,7 +9,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "5"
+  version: "6"
 ---
 
 # Spec Branch Fix
@@ -179,21 +179,28 @@ whether the branch is genuinely stalled.
 ## Commit
 
 Review and fix artifacts are part of the product — iteration and dismissal memory,
-and the human audit trail — so they are **always recorded and committed**. After
-verification passes, stage the changed code/tests plus
-`reviews/branch-<iteration>-review.md` and `-fix.md`, and commit:
+and the human audit trail — so they are **always written**. Commit them only when
+they are already tracked or are not ignored by Git. Before staging artifact paths,
+check `git ls-files --error-unmatch <path>` and `git check-ignore -q <path>`;
+never use `git add -f` / `--force` to override an ignore rule for `.specs/`
+artifacts. After verification passes, stage the changed code/tests plus any
+committable `reviews/branch-<iteration>-review.md` and `-fix.md`, and commit:
 
 ```txt
 fix(<scope>): address branch review (iter <iteration>)
 ```
 
 Append `(#<issue-number>)` if the spec footer names a GitHub issue. If nothing
-actionable was fixed (`material_change: false`), there is no code change — still
-commit the review and fix artifacts so the audit trail is durable:
+actionable was fixed (`material_change: false`), there is no code change. If the
+review artifacts are committable, commit them so the audit trail is durable:
 
 ```txt
 chore(reviews): record branch review (iter <iteration>)
 ```
+
+If the only changes are ignored, untracked `.specs/` review artifacts, do not make
+a commit. Leave the artifacts on disk and report that they were written locally but
+not committed because the repository ignores them.
 
 ## Completion Report
 
@@ -203,7 +210,8 @@ Report:
 2. Review file consumed and fix file written.
 3. Per-finding decisions (fixed / dismissed + class) in one line each.
 4. Verification commands and outcomes.
-5. Commit hash (the `fix(...)` or no-op `chore(reviews): ...` commit) and `material_change`.
+5. Commit hash (the `fix(...)` or no-op `chore(reviews): ...` commit, or `none`
+   when only ignored local review artifacts changed) and `material_change`.
 
 Do not add Co-Authored-By trailers, "Generated with" footers, or any AI model
 attribution.

--- a/skills/spec-branch-fix/SKILL.md
+++ b/skills/spec-branch-fix/SKILL.md
@@ -3,14 +3,13 @@ name: spec-branch-fix
 description: This skill should be used when the user or the spec-branch-refine loop asks to fix, apply, or act on a branch correctness review for one iteration — coupled to spec-branch-review only through the review file. It parses the review's YAML block, decides per finding whether to fix or dismiss (recording a dismissal class that controls re-raise suppression), applies the actionable fixes across the branch, runs tests, writes reviews/branch-<i>-fix.md, and always commits the review/fix artifacts. Trigger on "fix the branch review", "apply the branch review", "address the branch findings", or "spec branch fix".
 mode: coding
 scope: document
-capability: patcher
 disable-model-invocation: true
 argument-hint: "[spec=<path/to/spec.md>] [iter=<n>]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Spec Branch Fix

--- a/skills/spec-branch-refine/SKILL.md
+++ b/skills/spec-branch-refine/SKILL.md
@@ -9,7 +9,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "5"
+  version: "6"
 ---
 
 # Spec Branch Refine
@@ -70,9 +70,11 @@ refine was interrupted — resume rather than overwrite). Then:
    parsed for control flow.
 3. **Stop on clean or cap** — these two stops apply before any fix:
    - **Clean** — `verdict: pass` (no actionable findings). Stop; the branch is clean.
-     Commit the terminal review artifact (see Artifact Commit Policy).
+     Commit the terminal review artifact when it is tracked or not ignored (see
+     Artifact Commit Policy).
    - **Cap** — `i == max-iterations`. Stop; report the residual actionable findings,
-     and commit the terminal review artifact (see Artifact Commit Policy).
+     and commit the terminal review artifact when it is tracked or not ignored
+     (see Artifact Commit Policy).
 4. **Compute recurrence, then check stalled** — this order is what prevents both the
    premature stop and the oscillation:
    - **Recurrence set** = actionable signatures in `branch-<i>` that `branch-<i-1>-fix.md`
@@ -83,7 +85,8 @@ refine was interrupted — resume rather than overwrite). Then:
      unchanged from `branch-<i-1>`. That is a genuine dead end: fixing produced nothing
      and the same bugs remain. An identical actionable set after a fix that *did* change
      code is **not** stalled — it gets another iteration, with the recurrence set
-     terminalized (next bullet). Commit the terminal review artifact on this stop.
+     terminalized (next bullet). Commit the terminal review artifact on this stop
+     when it is tracked or not ignored.
 5. **Fix.** Run `spec-branch-fix` for iteration `i`. Pass the **recurrence set** as a
    *terminalize* instruction: each of those signatures must reach a terminal state
    this iteration — resolved by a genuinely *different* change, or **dismissed** with a
@@ -99,18 +102,23 @@ different fix or an explicit dismissal is still available.
 
 ## Artifact Commit Policy
 
-Review and fix artifacts are part of the product (iteration memory, dismissal memory,
-audit trail) and are always committed. `spec-branch-fix` commits the review+fix pair
-for any iteration it runs. But every terminal stop — **clean**, **cap**, and
+Review and fix artifacts are part of the product (iteration memory, dismissal
+memory, audit trail) and are always written. They are committed only when already
+tracked or not ignored by Git; never force-add ignored `.specs/` artifacts.
+`spec-branch-fix` commits the review+fix pair for any iteration it runs when those
+artifacts are committable. But every terminal stop — **clean**, **cap**, and
 **stalled** — happens *before* `spec-branch-fix` runs for iteration `i`, so on any of
-the three the driver owns committing that trailing `branch-<i>-review.md` itself:
+the three the driver owns the trailing `branch-<i>-review.md` artifact:
 
 ```txt
 chore(reviews): record branch review (iter <i>)
 ```
 
-This keeps the read-only reviewer from ever committing while still guaranteeing no
-review artifact is left uncommitted.
+Before staging it, check `git ls-files --error-unmatch <path>` and
+`git check-ignore -q <path>`. If the artifact is ignored and untracked, leave it on
+disk and report that no artifact commit was made because the repository ignores it.
+This keeps the read-only reviewer from ever committing while still guaranteeing the
+review artifact is recorded on disk.
 
 ## Reporting
 
@@ -124,7 +132,8 @@ Report:
    advisory findings never required to fix), with their `file:symbol` and signature.
 5. The review/fix artifact paths written under `<spec-dir>/reviews/`.
 6. The commit hashes produced (fix commits, plus any `chore(reviews):` artifact
-   commit the driver made on a clean/stalled stop).
+   commit the driver made on a clean/stalled stop), or note `none` when ignored
+   local artifacts were the only changes.
 
 A first-iteration `pass` is the common, good outcome on a well-built branch: report
 "clean after 1 review, no fixes needed."

--- a/skills/spec-branch-refine/SKILL.md
+++ b/skills/spec-branch-refine/SKILL.md
@@ -3,14 +3,13 @@ name: spec-branch-refine
 description: This skill should be used when the user asks to run the end-of-process branch correctness loop — review the whole branch, fix the findings, re-review, and repeat until clean or an iteration cap is reached. The in-process, file-backed replacement for an external review daemon's refine loop. It drives spec-branch-review and spec-branch-fix in alternation, holds the cross-iteration convergence and dedup state, and stops on a clean verdict, on no progress, or at the cap. The external review orchestrator runs it after the last step; it is also runnable standalone. Trigger on "refine the branch", "review-fix loop the branch", "run the branch correctness loop", "iterate review and fix until clean", or "spec branch refine".
 mode: coding
 scope: document
-capability: orchestrator
 disable-model-invocation: true
 argument-hint: "[spec=<path/to/spec.md>] [max-iterations=<n>]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Spec Branch Refine

--- a/skills/spec-branch-review/SKILL.md
+++ b/skills/spec-branch-review/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: spec-branch-review
 description: This skill should be used when the user or the spec-branch-refine loop asks to code-review or correctness-check the whole branch for bugs at the end of implementation. Reviews the branch diff (committed merge-base..HEAD by default, or the working tree including untracked files with scope=working-tree) in a spec-aware pass that decomposes the range into per-commit reviews and aggregates them (replicating roborev's per-commit→range design), then writes structured findings — a machine-readable YAML block plus prose — to reviews/branch-<i>-review.md. It runs a fixed core review (correctness, reference/contract integrity, security, simplification, AI-authorship tells) and fans out specialized lenses by risk (design, deep-security, data/deployment, dependency, performance, test-quality), delegating to existing skills where available. Read-only — it never edits code and never re-checks conformance (that is spec-audit). spec-branch-fix consumes its output. Trigger on "review the branch", "code-review the branch", "branch correctness review", "find bugs across the branch", or "spec branch review".
-mode: review
+mode: coding
 scope: document
-capability: reviewer
 disable-model-invocation: true
 argument-hint: "[spec=<path/to/spec.md>] [iter=<n>] [scope=committed|working-tree] [base=<ref>] [since=<commit>]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "8"
+  version: "9"
 ---
 
 # Spec Branch Review

--- a/skills/spec-branch-worktree/SKILL.md
+++ b/skills/spec-branch-worktree/SKILL.md
@@ -3,13 +3,12 @@ name: spec-branch-worktree
 description: "Create a named branch and git worktree for spec-driven work, then open it in a color-coded VSCode window. Use when: 'spec branch worktree', 'new spec worktree', 'worktree for', 'start a worktree', 'create worktree'."
 mode: coding
 scope: document
-capability: git-mutating
 argument-hint: "[description, feature-slug, or issue/ticket reference]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "6"
+  version: "7"
 ---
 
 # Spec Branch Worktree

--- a/skills/spec-branch/SKILL.md
+++ b/skills/spec-branch/SKILL.md
@@ -3,14 +3,13 @@ name: spec-branch
 description: This skill should be used when the user asks to "create a spec branch", "make a spec branch", "start a branch", or "branch from spec". Creates a local branch from a spec, description, or issue/ticket reference without requiring GitHub.
 mode: coding
 scope: document
-capability: git-mutating
 disable-model-invocation: true
 argument-hint: "[description, feature-slug, or issue/ticket reference]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Spec Branch

--- a/skills/spec-criteria/SKILL.md
+++ b/skills/spec-criteria/SKILL.md
@@ -3,14 +3,13 @@ name: spec-criteria
 description: This skill should be used when the user asks to "compile review criteria", "generate spec criteria", "compile the conformance checklist", "build guardrails from the spec", or "spec criteria". Compiles a frozen spec's normative prose into an executable conformance checklist at .specs/<slug>/criteria.md, blind to any implementation of that spec, and accumulates cross-phase ownership invariants in .specs/<slug>/invariants.md.
 mode: coding
 scope: document
-capability: repo-write
 disable-model-invocation: true
 argument-hint: "[feature-slug, spec path, or GitHub issue number]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Spec Criteria

--- a/skills/spec-remediate/SKILL.md
+++ b/skills/spec-remediate/SKILL.md
@@ -3,14 +3,13 @@ name: spec-remediate
 description: This skill should be used when the user asks to "remediate the audit findings", "fix the spec violations", "close the audit findings", "fix conformance violations", or "spec remediate". Reads a spec-audit report, drives one smart subagent per VIOLATION to converge the code back to the frozen spec, and re-audits until clean. Edits production code; never rewrites the spec.
 mode: coding
 scope: document
-capability: orchestrator
 disable-model-invocation: true
 argument-hint: "[feature-slug, spec path, or GitHub issue number]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "5"
+  version: "6"
 ---
 
 # Spec Remediate

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -3,14 +3,13 @@ name: spec-review
 description: This skill should be used when the user asks to "review a spec", "review an issue", "check the plan", "review the implementation plan", "find gaps in the spec", or "review spec". Reviews .specs/<slug>/spec.md for gaps and viability, edits it when needed, and mirrors changes to GitHub only when a GitHub mirror exists.
 mode: coding
 scope: document
-capability: repo-write
 disable-model-invocation: true
 argument-hint: "[feature-slug, spec path, or GitHub issue number]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "6"
+  version: "7"
 ---
 
 # Spec Review

--- a/skills/spec-run/SKILL.md
+++ b/skills/spec-run/SKILL.md
@@ -3,14 +3,13 @@ name: spec-run
 description: This skill should be used when the user asks to "execute the spec", "run the plan", "implement the spec", "implement the issue", "run all steps", or "run spec". Implements all steps from .specs/<slug>/spec.md, honoring criteria/invariants guardrails, using a subagent per step when the harness supports subagents, and committing each verified step separately.
 mode: coding
 scope: document
-capability: orchestrator
 disable-model-invocation: true
 argument-hint: "[feature-slug, spec path, GitHub issue number, optional criteria.md/invariants.md paths]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "8"
+  version: "9"
 ---
 
 # Spec Run

--- a/skills/spec-step-fix/SKILL.md
+++ b/skills/spec-step-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-step-fix
-description: This skill should be used when the user or an external task-runner asks to fix, apply, or act on a single step's correctness review — given only a step marker (spec path plus step). The mutating counterpart to spec-step-review: it reads reviews/<step>-review.md, decides per finding whether to fix or dismiss, applies the actionable fixes scoped to that step, runs targeted tests, writes reviews/<step>-fix.md, and commits. Self-sufficient by design — resolves the review file and the step's files deterministically from the spec directory. It is coupled to spec-step-review only through the review file. Trigger on "fix the step review", "apply the step review", "address the step's findings", or "spec step fix".
+description: This skill should be used when the user or an external task-runner asks to fix, apply, or act on a single step's correctness review — given only a step marker (spec path plus step). The mutating counterpart to spec-step-review: it reads reviews/<step>-review.md, decides per finding whether to fix or dismiss, applies the actionable fixes scoped to that step, runs targeted tests, writes reviews/<step>-fix.md, and commits code plus any review artifacts that are tracked or not ignored. Self-sufficient by design — resolves the review file and the step's files deterministically from the spec directory. It is coupled to spec-step-review only through the review file. Trigger on "fix the step review", "apply the step review", "address the step's findings", or "spec step fix".
 mode: coding
 scope: document
 disable-model-invocation: true
@@ -9,7 +9,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "3"
+  version: "4"
 ---
 
 # Spec Step Fix
@@ -163,9 +163,13 @@ Fix: <spec-dir>/reviews/step-<step-number>-fix.md (step <step-number>)
 ## Commit
 
 Review and fix artifacts are part of the product — iteration memory, dismissal
-memory, and the human audit trail — so they are **always recorded and committed**,
-never left dangling. After verification passes, stage this step's changed code/tests
-plus both `reviews/step-<step-number>-review.md` and `-fix.md`, and commit:
+memory, and the human audit trail — so they are **always written**. Commit them
+only when they are already tracked or are not ignored by Git. Before staging
+artifact paths, check `git ls-files --error-unmatch <path>` and
+`git check-ignore -q <path>`; never use `git add -f` / `--force` to override an
+ignore rule for `.specs/` artifacts. After verification passes, stage this step's
+changed code/tests plus any committable `reviews/step-<step-number>-review.md`
+and `-fix.md`, and commit:
 
 ```txt
 fix(<scope>): address step <step-number> review
@@ -173,12 +177,16 @@ fix(<scope>): address step <step-number> review
 
 Append `(#<issue-number>)` if a GitHub issue number is known from the spec footer.
 If nothing actionable was fixed (all dismissed / `verdict: pass`), there is no code
-change — still commit the review and fix artifacts on their own so the audit trail
-is durable:
+change. If the review artifacts are committable, commit them on their own so the
+audit trail is durable:
 
 ```txt
 chore(reviews): record step <step-number> review
 ```
+
+If the only changes are ignored, untracked `.specs/` review artifacts, do not make
+a commit. Leave the artifacts on disk and report that they were written locally but
+not committed because the repository ignores them.
 
 ## Completion Report
 
@@ -188,7 +196,8 @@ Report:
 2. Review file consumed and fix file written.
 3. Per-finding decisions (fixed / dismissed) in one line each.
 4. Verification commands and outcomes.
-5. Commit hash (the `fix(...)` or no-op `chore(reviews): ...` commit).
+5. Commit hash (the `fix(...)` or no-op `chore(reviews): ...` commit), or `none`
+   when only ignored local review artifacts changed.
 6. Anything deferred to the branch review (out-of-scope / `deferred` / `unfixable`).
 
 Do not add Co-Authored-By trailers, "Generated with" footers, or any AI model

--- a/skills/spec-step-fix/SKILL.md
+++ b/skills/spec-step-fix/SKILL.md
@@ -3,14 +3,13 @@ name: spec-step-fix
 description: This skill should be used when the user or an external task-runner asks to fix, apply, or act on a single step's correctness review — given only a step marker (spec path plus step). The mutating counterpart to spec-step-review: it reads reviews/<step>-review.md, decides per finding whether to fix or dismiss, applies the actionable fixes scoped to that step, runs targeted tests, writes reviews/<step>-fix.md, and commits. Self-sufficient by design — resolves the review file and the step's files deterministically from the spec directory. It is coupled to spec-step-review only through the review file. Trigger on "fix the step review", "apply the step review", "address the step's findings", or "spec step fix".
 mode: coding
 scope: document
-capability: patcher
 disable-model-invocation: true
 argument-hint: "spec=<path/to/spec.md> step=<number-or-exact-step>"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "2"
+  version: "3"
 ---
 
 # Spec Step Fix

--- a/skills/spec-step-judge/SKILL.md
+++ b/skills/spec-step-judge/SKILL.md
@@ -3,14 +3,13 @@ name: spec-step-judge
 description: This skill should be used when the user or an external task-runner asks to judge, evaluate, review, or "close out" a single already-implemented spec step — applying scoped corrections only if the step fell short, then adapting not-yet-run steps to what that step learned. It is the judging half of an externally-orchestrated, isolated per-step pipeline that pairs with spec-step-run (no spec-run orchestrator). Given only a step marker (spec path plus step), it is self-sufficient: it resolves the step's learning file, subspec, criteria.md, invariants.md, blockers.md, and applicable rules deterministically from the spec directory and needs no other context from the caller. Reads the step's learning file, evaluates the committed change against its Covers criteria and guardrails, fixes only that step when it failed, and rewrites the content of not-yet-run steps in spec.md — adding to, reducing, or replacing a future step's content, but never changing how many steps remain — with an Adaptations log, when learnings warrant. Trigger on "judge this step", "evaluate the step implementation", "review the implemented step", "apply step learnings", "adapt future steps", or "spec step judge".
 mode: coding
 scope: document
-capability: orchestrator
 disable-model-invocation: true
 argument-hint: "spec=<path/to/spec.md> step=<number-or-exact-step>"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "6"
+  version: "7"
 ---
 
 # Spec Step Judge

--- a/skills/spec-step-review/SKILL.md
+++ b/skills/spec-step-review/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: spec-step-review
 description: This skill should be used when the user or an external task-runner asks to review, code-review, or correctness-check a single already-implemented spec step for bugs — given only a step marker (spec path plus step). The read-only correctness counterpart to spec-step-judge: it hunts for logic, security, and over-complexity defects in that step's committed diff and writes a structured findings file at reviews/<step>-review.md. It never edits code and never re-checks conformance (that is spec-step-judge / spec-audit). Self-sufficient by design — resolves the step's commit, subspec, learning, criteria, and invariants deterministically from the spec directory. spec-step-fix consumes its output. Trigger on "review this step", "code-review the step", "correctness review the step", "find bugs in this step", or "spec step review".
-mode: review
+mode: coding
 scope: document
-capability: reviewer
 disable-model-invocation: true
 argument-hint: "spec=<path/to/spec.md> step=<number-or-exact-step>"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "2"
+  version: "3"
 ---
 
 # Spec Step Review

--- a/skills/spec-step-run/SKILL.md
+++ b/skills/spec-step-run/SKILL.md
@@ -3,14 +3,13 @@ name: spec-step-run
 description: This skill should be used when the user or an external task-runner asks to implement, run, execute, or complete exactly one step from a reviewed project-local spec, given only a step marker: the spec path plus the target step number/text. Self-sufficient by design — it resolves every related artifact (criteria.md, invariants.md, prior-step learnings, subspec, blockers.md, applicable rules) deterministically from the spec directory and needs no other context from the caller. Performs the same single-step planning, implementation, verification, and commit workflow as spec-run, but never runs every step or the whole acceptance gate. Built for externally-orchestrated, isolated per-step runs: it consumes earlier steps' learning files and always emits its own at learnings/<step>-learning.md that spec-step-judge and later steps consume.
 mode: coding
 scope: document
-capability: orchestrator
 disable-model-invocation: true
 argument-hint: "spec=<path/to/spec.md> step=<number-or-exact-step>"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "3"
+  version: "4"
 ---
 
 # Spec Step Run

--- a/skills/spec-subspec-write/SKILL.md
+++ b/skills/spec-subspec-write/SKILL.md
@@ -3,14 +3,13 @@ name: spec-subspec-write
 description: This skill should be used when the user asks to "write a subspec", "plan this step", "write a step plan", or "detail step N" for a single implementation step that already exists in a reviewed spec. Creates a minimal, code-grounded implementation plan for one step at .specs/<slug>/subspecs/<step-number>-spec.md. spec-run and spec-step-run invoke this contract per step before coding.
 mode: coding
 scope: document
-capability: repo-write
 disable-model-invocation: true
 argument-hint: "[step-number] [feature-slug or spec path (optional)]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "4"
+  version: "5"
 ---
 
 # Spec Subspec Write

--- a/skills/spec-write/SKILL.md
+++ b/skills/spec-write/SKILL.md
@@ -3,14 +3,13 @@ name: spec-write
 description: This skill should be used when the user asks to "write a spec", "create a spec", "spec this out", "plan this feature", or "write an implementation plan" for a feature or change. Creates a structured implementation spec in .specs/<slug>/spec.md and mirrors it to GitHub only when the current repository is hosted on GitHub.
 mode: coding
 scope: document
-capability: repo-write
 disable-model-invocation: true
 argument-hint: "[feature-slug or GitHub issue number (optional)]"
 license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "9"
+  version: "10"
 ---
 
 # Spec Write

--- a/skills/spec-write/SKILL.md
+++ b/skills/spec-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-write
-description: This skill should be used when the user asks to "write a spec", "create a spec", "spec this out", "plan this feature", or "write an implementation plan" for a feature or change. Creates a structured implementation spec in .specs/<slug>/spec.md and mirrors it to GitHub only when the current repository is hosted on GitHub.
+description: This skill should be used when the user asks to "write a spec", "create a spec", "spec this out", "plan this feature", or "write an implementation plan" for a feature or change. Creates a structured implementation spec in .specs/<slug>/spec.md and automatically mirrors it to GitHub when the current repository is hosted on GitHub, `gh` is authenticated, and the user has not opted out.
 mode: coding
 scope: document
 disable-model-invocation: true
@@ -9,12 +9,12 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "10"
+  version: "11"
 ---
 
 # Spec Write
 
-Create a deterministic implementation spec from the current proposal and persist it to the repository-local spec folder. The local file is canonical; issue trackers are optional mirrors.
+Create a deterministic implementation spec from the current proposal and persist it to the repository-local spec folder. The local file is canonical; GitHub issues are automatic mirrors when available and not explicitly disabled.
 
 ## Non-Interactive Operation
 
@@ -30,13 +30,14 @@ Always write the completed spec to:
 .specs/<feature-slug>/spec.md
 ```
 
-If the current repository is a GitHub repository and `gh` is authenticated, also mirror the same spec body to a GitHub issue:
+If the current repository is a GitHub repository and `gh` is authenticated, also mirror the same spec body to a GitHub issue without asking for confirmation, unless the user explicitly says not to mirror:
 
 - If `$ARGUMENTS` is an issue number, edit that issue.
 - If no issue number is provided, create a new issue.
+- If the user explicitly opts out of GitHub mirroring, skip the mirror and report the local spec path.
 - If GitHub is unavailable, unauthenticated, or the repo is hosted elsewhere, skip the mirror and report the local spec path.
 
-Do not require GitHub for this workflow. Bitbucket, GitLab, self-hosted, and local-only repositories use `.specs/<feature-slug>/spec.md` only.
+Do not require GitHub for this workflow. Bitbucket, GitLab, self-hosted, and local-only repositories use `.specs/<feature-slug>/spec.md` only. Do not ask whether to mirror in the normal GitHub case; the default is yes.
 
 ## Pre-Step - Load Pipeline Inputs
 
@@ -67,13 +68,14 @@ When writing a phase spec:
 
 ## GitHub Mirror Detection
 
-Treat GitHub as an optional mirror only when all of these are true:
+Treat GitHub as an automatic mirror only when all of these are true:
 
 1. `git remote get-url origin` identifies a GitHub remote, such as `git@github.com:owner/repo.git` or `https://github.com/owner/repo.git`.
 2. `command -v gh` succeeds.
 3. `gh auth status` succeeds for the remote host.
+4. The user has not explicitly opted out of mirroring for this run.
 
-If any check fails, continue with the local `spec.md` output and report why the GitHub mirror was skipped. Do not block spec creation on issue-tracker access.
+If any check fails, continue with the local `spec.md` output and report why the GitHub mirror was skipped. Do not block spec creation on issue-tracker access, and do not ask for confirmation before mirroring when all checks pass.
 
 ## Issue-ID Folder Prefix
 

--- a/skills/specops-analysis/SKILL.md
+++ b/skills/specops-analysis/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "2"
+  version: "3"
 ---
 
 # SpecOps Analysis
@@ -20,6 +20,16 @@ If `$ARGUMENTS` is not provided, infer `TARGET_SCOPE` from the request and repos
 Analyze all relevant evidence for `TARGET_SCOPE`, including source code, tests, docs, configs, schemas, runbooks, migrations, fixtures, seeds, job definitions, telemetry hooks, user-facing text, and operational artifacts when present.
 
 When ambiguity exists, explicitly call it out. Do not silently infer intent.
+
+## Manifest-driven invocation
+
+When the orchestrator invokes this skill with a manifest target entry (instead of a free-text target scope), read `name`, `scope`, the effective `source_globs`, and `tier2_path` directly from that entry — do not infer `TARGET_SCOPE`.
+
+- Use `source_globs` as the analysis scope.
+- Write the resulting spec to the entry's `tier2_path` instead of choosing an output path.
+- Return the analyzed `source_hash` — the unit-relative content hash over the target's `source_globs` — so the orchestrator can stamp manifest freshness.
+
+This is only an alternate entry path. All analysis behavior below is unchanged.
 
 ## Analysis Expectations
 

--- a/skills/specops-decompose/SKILL.md
+++ b/skills/specops-decompose/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: specops-decompose
+description: This skill should be used when the user asks to decompose a repository into a stable, machine-readable SpecOps target manifest (docs/specops/targets.json) — running the deterministic skeleton-derivation core, filling in per-target name and scope prose and the system summary, and reporting coverage, renames, and low-confidence to the orchestrator.
+disable-model-invocation: true
+argument-hint: "[repo-root (optional)]"
+license: MIT
+metadata:
+  author: Ryan Mahoney
+  homepage: ryan-mahoney.net
+  version: "1"
+---
+
+# SpecOps Decompose
+
+Produce a stable `docs/specops/targets.json` manifest for a repository. This is a leaf skill: a
+thin LLM layer over the deterministic core `scripts/decompose-skeleton.mjs`. The script owns the
+partition — slugs, structural units, source globs, coverage, content hashes, overrides, and
+renames. You own only prose: per-target `name` and `scope`, and the `system` summary. The only
+stochastic output is that prose. Do not orchestrate; do not run other skills.
+
+## Input
+
+If `$ARGUMENTS` is provided, treat it as `REPO_ROOT`. Otherwise default `REPO_ROOT` to `.`
+(the current repository).
+
+## Procedure
+
+### 1. Run the deterministic core
+
+Run the script and capture the JSON it prints to stdout:
+
+```bash
+node scripts/decompose-skeleton.mjs <REPO_ROOT>
+```
+
+If `docs/specops/targets.json` already exists in the target repo, pass it so curated prose,
+overrides, and renames are reconciled and preserved:
+
+```bash
+node scripts/decompose-skeleton.mjs <REPO_ROOT> --manifest docs/specops/targets.json
+```
+
+The script prints the full structural manifest (pretty-printed JSON). Parse it; this is your
+working object. On a reconcile run it has already carried forward `name`, `scope`, and
+`last_synthesized` for slugs present in both manifests.
+
+### 2. Treat the structural output as authoritative and immutable
+
+The script's structural fields are the contract. **Never edit** any of:
+
+- `slug`
+- `structural_unit`
+- `source_globs`
+- `origin`
+- `source_hash`
+- `coverage` (`unassigned`, `overlaps`, `low_confidence`)
+- `overrides`
+- `renames`
+
+These are derived deterministically so re-runs do not churn. Editing them breaks `--check` and
+silently moves the partition. This is the load-bearing guardrail of the whole pipeline: the LLM
+can never move the partition, the slugs, the globs, or the coverage. Do not re-derive the
+partition yourself.
+
+### 3. Author name and scope for new targets
+
+For each target with an empty `name` or empty `scope`, author concise prose:
+
+- `name`: a short, human-readable label for the unit (a noun phrase, not the slug).
+- `scope`: ONE line describing what the unit is responsible for.
+
+Use light reconnaissance to ground the prose — read the unit's entry points and a few key files.
+For a large repo you may spawn **at most one level** of `Explore` subagents (the suite's
+one-subagent-deep bound). Do not nest subagents. Do not re-partition. Front-load the scope: lead
+with the responsibility, omit needless words, no marketing language.
+
+### 4. Write or refresh the system summary
+
+Set the top-level `system` object:
+
+- `system.summary`: one paragraph describing what the whole repository is and does.
+- `system.external_dependencies`: the notable third-party services, runtimes, or platforms the
+  system depends on (array of strings).
+
+On a reconcile run, refresh these if the system has changed; otherwise leave a sound prior
+summary in place.
+
+### 5. Write the manifest
+
+Write the final, complete manifest object to `docs/specops/targets.json` in the target repo,
+pretty-printed (2-space indent). Preserve every structural field from the script byte-for-byte;
+your edits touch only `name`, `scope`, and `system`.
+
+### 6. Validate (optional but recommended)
+
+Re-derive and validate structural integrity:
+
+```bash
+node scripts/decompose-skeleton.mjs <REPO_ROOT> --check docs/specops/targets.json
+```
+
+Exit `0` means the manifest's structural fields agree with a fresh derivation and the schema is
+valid. A nonzero exit prints each violation to stderr — report them; do not silently edit
+structural fields to make the check pass.
+
+### 7. Report to the caller
+
+Return a short report to the orchestrator that names, explicitly:
+
+- `coverage.unassigned` — source files matched by no target (gaps the orchestrator may resolve
+  with an override).
+- `renames` — `{old_slug, new_slug}` entries the script detected (a target whose directory moved
+  with unchanged content); the orchestrator should migrate the corresponding spec.
+- `coverage.low_confidence` — `true` when no module system was detectable and the repo collapsed
+  to a single root unit; signals the partition needs human review.
+
+Also state the manifest path written and any `--check` violations.
+
+## Guardrail
+
+This skill writes **only** `docs/specops/targets.json`. It must not write per-target specs, an
+`AGENTS.md`, or any other file. If reconnaissance suggests a target's spec is stale, report it —
+do not generate or edit it here.
+
+## Reference: manifest schema
+
+The manifest an implementer must produce (and the script emits) has this shape. Transcribed so
+you can reproduce it without reading the script:
+
+```jsonc
+{
+  "version": 1,
+  "system": { "summary": "string (one paragraph)", "external_dependencies": ["string"] },
+  "targets": [
+    {
+      "slug": "string",            // kebab-case, unique, derived deterministically from structural_unit
+      "name": "string",            // LLM-authored
+      "scope": "string",           // LLM-authored, one line
+      "origin": "derived" | "override",
+      "structural_unit": "string", // repo-relative path the slug derives from, e.g. "packages/submissions"
+      "source_globs": ["string"],  // >=1; generated projection of the unit (and overrides), never hand-authored
+      "tier2_path": "docs/specops/analysis/<slug>.md",
+      "source_hash": "sha256:…" | null,
+      "last_synthesized": "ISO-8601" | null
+    }
+  ],
+  "overrides": [
+    { "op": "merge", "units": ["path", "…"], "into": "slug" },
+    { "op": "split", "unit": "path", "into": [ { "slug": "string", "subpath": "string" } ] },
+    { "op": "relabel", "unit": "path", "name": "string", "scope": "string" }
+  ],
+  "renames": [ { "old_slug": "string", "new_slug": "string" } ],
+  "coverage": {
+    "unassigned": ["path"],
+    "overlaps": [ { "path": "string", "slugs": ["string", "…"] } ],
+    "low_confidence": false
+  }
+}
+```
+
+`name` and `scope` are LLM-authored; `system.summary` and `system.external_dependencies` are
+LLM-authored. Every other field is derived by the script. `overrides` are author-supplied curation
+the script applies; you never invent them in this skill.
+
+## Reference: slug rule
+
+The script derives each `slug` from the `structural_unit` path so the same path yields the same
+slug on every run:
+
+1. Lowercase the path.
+2. Replace each run of non-alphanumeric characters with a single `-`.
+3. Trim leading and trailing `-`.
+4. On collision with an already-taken slug, append the parent path segment (then the next
+   ancestor, and so on) until the slug is unique.
+
+Same `structural_unit` path ⇒ same slug, every run. A single root unit slugs to `root`.
+
+## Reference: source_hash basis
+
+`source_hash` is a content hash, not a file-list-plus-mtime stamp. The script computes it as:
+
+`"sha256:" + sha256( the path-sorted, newline-joined list of `relpath \0 sha256(file-contents)` for every file matched by the target's effective source_globs )`
+
+`relpath` is **unit-relative** — the matching glob's base path is stripped, so the path is
+relative to the unit, not the repo. Consequences, by design:
+
+- Unchanged across an mtime-only touch (it hashes contents, not timestamps).
+- Unchanged across a directory rename that preserves content (the glob base is stripped, so the
+  relative paths and contents are identical) — this is what lets rename detection match old→new.
+- Changes if and only if the matched content changes.
+
+This is why a content-preserving rename produces a `renames` entry while a rename with content
+edits is reported as a removal plus an addition for the orchestrator to resolve.

--- a/skills/specops-initial-plan/SKILL.md
+++ b/skills/specops-initial-plan/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "1"
+  version: "2"
 ---
 
 # SpecOps Initial Plan
@@ -20,6 +20,14 @@ If `$ARGUMENTS` is not provided, infer `TARGET_SCOPE` from user request and repo
 Discover and analyze source artifacts relevant to `TARGET_SCOPE`, including code, tests, configs, schemas, and docs.
 
 When details are ambiguous or missing, explicitly mark uncertainty. Do not silently infer business rules.
+
+## Scope
+
+Multi-target decomposition now lives in the `specops-decompose` skill. This skill is
+scoped to SINGLE-TARGET deep-planning of one `TARGET_SCOPE`. To produce the multi-target
+manifest (`docs/specops/targets.json`), use `specops-decompose`, not this skill.
+
+The analysis instructions below are unchanged.
 
 ## Required Output Sections
 

--- a/skills/specops-orchestrate-analysis/SKILL.md
+++ b/skills/specops-orchestrate-analysis/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   author: Ryan Mahoney
   homepage: ryan-mahoney.net
-  version: "2"
+  version: "3"
 ---
 
 # SpecOps Orchestrate Analysis
@@ -20,6 +20,16 @@ Primary objective:
 - Ensure per-target analysis outputs are produced consistently and verified before moving to the next target.
 
 Do not generate specs. Do not implement product code directly unless subagents are unavailable.
+
+## Status
+
+DEPRECATED for the decomposition-first AGENTS documentation pipeline. An external
+orchestrator — driving `specops-decompose` for the persisted target manifest and a
+per-target `specops-analysis` pass — supersedes this skill for that pipeline.
+
+It remains a documented LOCAL FALLBACK: use it to run an analysis pipeline from a
+single initial-plan artifact when the external orchestrator is unavailable. The
+orchestration instructions below are unchanged.
 
 ## Inputs
 

--- a/skills/specops-update-spec/SKILL.md
+++ b/skills/specops-update-spec/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: specops-update-spec
+description: This skill should be used when the user asks to update one SpecOps target's deep spec in place from a branch or diff — re-reading the target's tier2_path spec and the changed files, editing only the sections traceable to the diff, re-validating Evidence file references, and returning the target's refreshed source_hash and last_synthesized to the orchestrator.
+disable-model-invocation: true
+argument-hint: "[target manifest entry + branch/diff context]"
+license: MIT
+metadata:
+  author: Ryan Mahoney
+  homepage: ryan-mahoney.net
+  version: "1"
+---
+
+# SpecOps Update Spec
+
+Update ONE target's deep spec in place from a branch or diff. This is a Phase 2 leaf skill: the
+orchestrator passes a single target's manifest entry plus the branch/diff context, and you edit
+that one spec to match the change, then return a refreshed freshness stamp. The read-and-edit-in-
+place model is the point — you do not regenerate the spec, you patch the parts the diff touched.
+Do not orchestrate; do not run other skills.
+
+## Input
+
+The orchestrator passes you, for ONE target:
+
+- The target's **manifest entry** — `slug`, `name`, `scope`, `source_globs`, `tier2_path`,
+  `source_hash`, `last_synthesized`.
+- **Branch/diff context** — the branch under review and the file diff (or enough to reconstruct
+  the changed paths and hunks).
+
+You do **not** read `docs/specops/targets.json` yourself. The orchestrator owns the manifest and
+hands you the one entry you need.
+
+## Procedure
+
+### 1. Read the existing spec and the changed files
+
+Read the existing spec at the target's `tier2_path`. Read the changed files from the diff, scoped
+to the target's `source_globs` — only changes that fall inside this target's globs are yours to
+reflect. Note the changed paths and the specific hunks; those map to the spec sections you may edit.
+
+For a large change you may spawn **at most one level** of `Explore` subagents to locate the spec
+sections affected by the diff (the suite's one-subagent-deep bound). Do not nest subagents.
+
+### 2. Edit the spec in place
+
+Change **only** the sections traceable to the diff. Preserve the document's structure and leave
+untouched sections **byte-for-byte unchanged**. Do not rewrite the whole spec, do not reorder
+sections, do not reflow prose that the diff did not affect. Use targeted edits, not a full rewrite.
+
+For each changed hunk, find the section that describes that behavior (interface, data model,
+behavioral contract, rule, side effect, etc.) and update it to match the new code. If the diff
+adds behavior with no corresponding section, add it in the matching place; if it removes behavior,
+remove or correct the stale section. Keep the edit minimal and traceable to the diff.
+
+### 3. Re-validate Evidence file references
+
+A SpecOps deep spec cites source files under `Evidence` subsections (see `specops-analysis`). Walk
+those references and re-validate them:
+
+- **Existence check (mechanical):** for each path cited in an `Evidence` subsection, confirm the
+  file still exists at that path. Flag every reference whose file no longer exists (moved, renamed,
+  or deleted) so the orchestrator knows the citation is broken.
+- **Stale-surrounding-code check:** for each Evidence reference whose file **did change in the
+  diff**, flag it — the cited code moved or changed, so the spec text around that reference may
+  need updating even if the path still resolves.
+
+Report both lists. Fix the Evidence references you can fix from the diff with confidence; flag the
+rest for the orchestrator rather than guessing.
+
+### 4. Recompute and return the refreshed source_hash and last_synthesized
+
+Recompute the target's `source_hash` over its effective `source_globs`, using the same hashing the
+decomposition core uses, and capture a fresh `last_synthesized` timestamp. You **return** these to
+the orchestrator — you do **not** write them into the manifest yourself (the orchestrator owns the
+manifest write).
+
+Use one of the two mechanisms the committed script actually supports:
+
+- **Single target (simpler).** Import the exported `sourceHash` and call it over this target's
+  globs:
+
+  ```bash
+  node --input-type=module -e \
+    'import { sourceHash } from "./scripts/decompose-skeleton.mjs"; console.log(sourceHash("<REPO_ROOT>", ["<unit>/**"]))'
+  ```
+
+  Pass the target's actual `source_globs` array. This prints `sha256:<hex>` — the exact value the
+  script would store for that target.
+
+- **Whole-manifest reconcile.** If the orchestrator wants every target reconciled at once, it can
+  run `node scripts/decompose-skeleton.mjs <REPO_ROOT> --manifest docs/specops/targets.json`; the
+  printed JSON carries the freshly recomputed `source_hash` for this target's slug. Read it from
+  there.
+
+Both yield the same hash for a given target's globs. For `last_synthesized`, use the current
+UTC time in ISO-8601 (e.g. `2026-06-21T00:00:00Z`).
+
+There is no per-target hash CLI flag — these are the only supported paths. Do not invent one.
+
+## Guardrail
+
+Edit **only** this target's own `tier2_path` spec. Do not touch any sibling target's spec, the
+manifest, or any other file. Sibling specs stay untouched.
+
+If the diff implicates a path owned by **no** target — a changed file that falls outside this
+target's `source_globs` and is not covered by another known target — do **not** invent a target and
+do **not** stretch this spec to cover it. Report the unowned path to the orchestrator so it can run
+a `specops-decompose` re-run to re-derive the partition. Inventing a target here would silently move
+the partition the decomposition core owns.
+
+## Return to the orchestrator
+
+Return a short report containing:
+
+- The refreshed `source_hash` (`sha256:…`) and the fresh `last_synthesized` timestamp, for the
+  orchestrator to write back into the manifest.
+- The spec sections you changed, each tied to the diff hunk that prompted it.
+- Evidence re-validation findings: references whose files no longer exist, and references whose
+  surrounding code changed in the diff.
+- Any unowned paths in the diff that need an orchestrator-driven `specops-decompose` re-run.


### PR DESCRIPTION
## Summary

Implements Phase 1–2 of the decomposition-first AGENTS documentation pipeline: a stable, machine-readable record of *what a repo's targets are*, plus an in-place per-target spec updater. Decomposition was previously transient (computed inside `agents-update` recon and `specops-orchestrate-analysis`, then discarded); this gives an external orchestrator a durable spine that re-runs without churn.

The design splits work into a **deterministic core** (a dependency-free Node script that owns slugs, globs, coverage, hashes, overrides, and renames) and a **thin LLM layer** (a skill that owns only prose). The LLM can never move the partition.

## What changed

**New deterministic core** — `scripts/decompose-skeleton.mjs` (built-ins only, Node ≥ 22) with a `node:test` suite (19 tests):
- **derive**: module-system detection (workspace packages → conventional source roots → top-level dirs → single low-confidence root), deterministic kebab-case slugs, `source_globs`, and coverage (`unassigned`/`overlaps`/`low_confidence`).
- **source_hash**: sha256 over the unit-relative, path-sorted `relpath \0 sha256(content)` list — stable across mtime-only changes and content-preserving directory renames, changes iff matched content changes.
- **reconcile** (`--manifest`): carries forward curated `name`/`scope`/`last_synthesized` for unchanged slugs; always recomputes membership and hash.
- **overrides** (`merge`/`split`/`relabel`) and conservative **rename detection** (auto-renames only on exact content-hash match; otherwise reports remove+add).
- **check** (`--check`): schema + membership-equality gate; exits nonzero on any violation.

**New leaf skills:**
- `skills/specops-decompose/SKILL.md` — runs the core, authors prose, writes `docs/specops/targets.json`, reports coverage/renames/low-confidence. Writes only the manifest. Documents the schema, slug rule, and hash basis.
- `skills/specops-update-spec/SKILL.md` — updates one target's deep spec in place from a branch diff, re-validates Evidence references, returns a refreshed `source_hash`.

**Modified skills:**
- `specops-analysis` — added a "Manifest-driven invocation" note (reads a manifest entry, writes to `tier2_path`, returns the analyzed `source_hash`).
- `specops-initial-plan` — narrowed to single-target deep-planning; decomposition now lives in `specops-decompose`.
- `specops-orchestrate-analysis` — marked deprecated for this pipeline; retained as a documented local fallback.

## Verification

- `node --test scripts/decompose-skeleton.test.mjs` → 19/19 pass (covers AC-1 through AC-10).
- `scripts/lint-skills.sh --all` → 0 errors (AC-11).
- Skill ACs (AC-13–AC-17) verified by lint + body inspection, per the spec's run-and-inspect note.

## Notes

- During implementation, the `source_hash` basis was corrected to **unit-relative** paths so a content-preserving directory rename produces an equal hash (required by AC-5); mtime-stability and content-sensitivity (AC-6/AC-7) are preserved.
- Phase 3 (root `AGENTS.md` index consuming this manifest) is deferred, per the spec.

Closes #3
